### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/javascripts/discourse/api-initializers/user_card_on_hover.js
+++ b/javascripts/discourse/api-initializers/user_card_on_hover.js
@@ -2,70 +2,72 @@ import { apiInitializer } from "discourse/lib/api";
 import { bind } from "discourse/lib/decorators";
 
 export default apiInitializer("0.11.1", (api) => {
-  api.modifyClass("component:user-card-contents", {
-    pluginId: "discourse-user-card-on-hover",
+  api.modifyClass(
+    "component:user-card-contents",
+    (Superclass) =>
+      class extends Superclass {
+        didInsertElement() {
+          super.didInsertElement(...arguments);
 
-    didInsertElement() {
-      this._super(...arguments);
+          this.appEvents.on("card:show", this, this.onShow);
+          this.appEvents.on("card:hide", this, this.onHide);
 
-      this.appEvents.on("card:show", this, this.onShow);
-      this.appEvents.on("card:hide", this, this.onHide);
+          const mainOutlet = document.querySelector("#main-outlet");
+          mainOutlet.addEventListener("mouseover", this.showCard);
+          mainOutlet.addEventListener("mouseout", this.hideCard);
+        }
 
-      const mainOutlet = document.querySelector("#main-outlet");
-      mainOutlet.addEventListener("mouseover", this.showCard);
-      mainOutlet.addEventListener("mouseout", this.hideCard);
-    },
+        willDestroyElement() {
+          super.willDestroyElement(...arguments);
 
-    willDestroyElement() {
-      this._super(...arguments);
+          this.appEvents.off("card:show", this, this.onShow);
+          this.appEvents.off("card:hide", this, this.onHide);
 
-      this.appEvents.off("card:show", this, this.onShow);
-      this.appEvents.off("card:hide", this, this.onHide);
+          const mainOutlet = document.querySelector("#main-outlet");
+          mainOutlet.removeEventListener("mouseover", this.showCard);
+          mainOutlet.removeEventListener("mouseout", this.hideCard);
+        }
 
-      const mainOutlet = document.querySelector("#main-outlet");
-      mainOutlet.removeEventListener("mouseover", this.showCard);
-      mainOutlet.removeEventListener("mouseout", this.hideCard);
-    },
+        onShow(_username, _target, event) {
+          this.set("lastEvent", event);
+        }
 
-    onShow(_username, _target, event) {
-      this.set("lastEvent", event);
-    },
+        onHide() {
+          this.set("lastEvent", null);
+        }
 
-    onHide() {
-      this.set("lastEvent", null);
-    },
+        @bind
+        showCard(event) {
+          if (this.lastEvent && this.lastEvent.type === "click") {
+            return;
+          }
 
-    @bind
-    showCard(event) {
-      if (this.lastEvent && this.lastEvent.type === "click") {
-        return;
+          this._cardClickHandler(event);
+        }
+
+        @bind
+        hideCard(event) {
+          if (this.lastEvent && this.lastEvent.type === "click") {
+            return;
+          }
+
+          if (this.avatarSelector) {
+            this._hideCard(event, this.avatarSelector);
+          }
+
+          if (this.mentionSelector) {
+            this._hideCard(event, this.mentionSelector);
+          }
+        }
+
+        _hideCard(event, selector) {
+          const hadCard = !!event.fromElement?.closest(selector);
+          const hasCard = !!event.toElement?.closest(selector);
+
+          if (hadCard && !hasCard) {
+            this._close();
+          }
+        }
       }
-
-      this._cardClickHandler(event);
-    },
-
-    @bind
-    hideCard(event) {
-      if (this.lastEvent && this.lastEvent.type === "click") {
-        return;
-      }
-
-      if (this.avatarSelector) {
-        this._hideCard(event, this.avatarSelector);
-      }
-
-      if (this.mentionSelector) {
-        this._hideCard(event, this.mentionSelector);
-      }
-    },
-
-    _hideCard(event, selector) {
-      const hadCard = !!event.fromElement?.closest(selector);
-      const hasCard = !!event.toElement?.closest(selector);
-
-      if (hadCard && !hasCard) {
-        this._close();
-      }
-    },
-  });
+  );
 });


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely